### PR TITLE
对import()延时处理

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -2,9 +2,12 @@ module.exports = function () {
   this.cacheable && this.cacheable();
   return ` 
     import AutoReloadIcon from 'webpack-ant-icon-loader/src/runtime.js';
-    import('!!./dist.js').then(function(allIcons) { 
+    // 加载script标签会阻塞js执行，antd部分组件（如表格）无法在一轮循环内完成完整的渲染，故延时
+    setTimeout(() => {
+      import('!!./dist.js').then(function(allIcons) { 
         AutoReloadIcon.load(allIcons); 
-    }); 
+      }); 
+    });
     export default { 
       name:'add', 
       theme:'fill' 


### PR DESCRIPTION
加载script标签会阻塞js执行，antd部分组件（如表格）无法在一轮循环内完成完整的渲染，故延时